### PR TITLE
Run CI on host machine

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   lab0-c:
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     steps:
     - uses: actions/checkout@v3.3.0
     - uses: webfactory/ssh-agent@v0.7.0
@@ -31,7 +31,7 @@ jobs:
             cat scripts/pikachu.raw
 
   coding-style:
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     steps:
     - uses: actions/checkout@v3.3.0
     - name: coding convention


### PR DESCRIPTION
The reason for running CI on host machine is because running CI on Github failed at testcase no.14 which is "trace-14-perf.cmd". Currently, I ran [act](https://github.com/nektos/act) which simulated the same environment as running on Github on host machine and it still worked right. So, I have no idea about what happened on Github now. That's why I make a decision to run CI on host machine instead.